### PR TITLE
summary snippets added

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,13 @@
                 "title": "Setup Remote Docker Folder",
                 "category": "Navertical"
             }
+        ],
+        "snippets": [
+            {
+                "language": "al",
+                "path": "./src/nvr-snippets.json",
+                "category": "Navertical"
+            }
         ]
     },
     "scripts": {

--- a/src/nvr-snippets.json
+++ b/src/nvr-snippets.json
@@ -16,7 +16,7 @@
 			"summ param"
 		],
 		"body": [
-			"/// <param name='${1:Name}'>${2:Description}</param>"
+			"/// <param name=\"${1:Name}\">${2:Description}</param>"
 		],
 		"description": "Summary parameter for AL",
 		"scope": "al"
@@ -29,8 +29,21 @@
 			"/// <summary>",
 			"/// ${1:Summary}",
 			"/// </summary>",
-			"/// <param name='${2:Name}'>${3:Description}</param>",
-			"/// <param name='${4:Name}'>${5:Description}</param>"
-		]
+			"/// <param name=\"${2:Name\">${3:Description}</param>",
+			"/// <param name=\"${4:Name}\">${5:Description}</param>",
+			"/// <returns>${6:Returns}</returns>"
+		],
+		"description": "Full summary for AL",
+		"scope": "al"
+	},
+	"NVR Summary Return": {
+		"prefix": [
+			"summ return"
+		],
+		"body": [
+			"/// <returns>${1:Returns}</returns>"
+		],
+		"description": "Summary returns for AL",
+		"scope": "al"
 	}
 }

--- a/src/nvr-snippets.json
+++ b/src/nvr-snippets.json
@@ -1,0 +1,29 @@
+{
+	"NVR Summary": {
+		"prefix": [
+			"summary returns",
+			"summr"
+		],
+		"body": [
+			"///<summary>",
+			"/// ${1:Summary}",
+			"///</summary>",
+			"///<returns>${2:returns}</returns>"
+		],
+		"description": "Summary for AL with returns",
+		"scope": "al"
+	},
+	"NVR Summary Void": {
+		"prefix": [
+			"summary void",
+			"summv"
+		],
+		"body": [
+			"///<summary>",
+			"/// ${1:Summary}",
+			"///</summary>"
+		],
+		"description": "Summary for AL",
+		"scope": "al"
+	}
+}

--- a/src/nvr-snippets.json
+++ b/src/nvr-snippets.json
@@ -1,29 +1,36 @@
 {
 	"NVR Summary": {
 		"prefix": [
-			"summary returns",
-			"summr"
+			"summ"
 		],
 		"body": [
-			"///<summary>",
+			"/// <summary>",
 			"/// ${1:Summary}",
-			"///</summary>",
-			"///<returns>${2:returns}</returns>"
-		],
-		"description": "Summary for AL with returns",
-		"scope": "al"
-	},
-	"NVR Summary Void": {
-		"prefix": [
-			"summary void",
-			"summv"
-		],
-		"body": [
-			"///<summary>",
-			"/// ${1:Summary}",
-			"///</summary>"
+			"/// </summary>"
 		],
 		"description": "Summary for AL",
 		"scope": "al"
+	},
+	"NVR Summary Param": {
+		"prefix": [
+			"summ param"
+		],
+		"body": [
+			"/// <param name='${1:Name}'>${2:Description}</param>"
+		],
+		"description": "Summary parameter for AL",
+		"scope": "al"
+	},
+	"NVR Summary Full": {
+		"prefix": [
+			"summ full"
+		],
+		"body": [
+			"/// <summary>",
+			"/// ${1:Summary}",
+			"/// </summary>",
+			"/// <param name='${2:Name}'>${3:Description}</param>",
+			"/// <param name='${4:Name}'>${5:Description}</param>"
+		]
 	}
 }


### PR DESCRIPTION
In .al we can now use snippet summv (summary void) for summary with type void and summr (summary returns) with return type.